### PR TITLE
Fix crash when config.generator.max_length > 50

### DIFF
--- a/gan_train.py
+++ b/gan_train.py
@@ -97,7 +97,7 @@ def gan_train(config):
                 ##sample_str=du.indices_to_words(y_sample_dealed, 'dst')
                 ##print(sample_str)
                 #
-                x_to_maxlen = extend_sentence_to_maxlen(x)
+                x_to_maxlen = extend_sentence_to_maxlen(x, config.generator.max_length)
                 logging.info("calculate the reward")
                 rewards = generator.get_reward(x=x,
                                                x_to_maxlen=x_to_maxlen,


### PR DESCRIPTION
When `config.generator.max_length > 50`,  `extend_sentence_to_maxlen` can fail with the below error if generated sentences `x` are > length 50 :
```
share_function.py", line 244, in extend_sentence_to_maxlen
    x[idx, :len(seq)]=seq
ValueError: could not broadcast input array from shape (51) into shape (50)
```